### PR TITLE
dispose websocket listeners on single game in tournament * since the socket stays open during the whole tournament there are possibly a lot of listeners leaking memory

### DIFF
--- a/server/communication/clientApi.js
+++ b/server/communication/clientApi.js
@@ -1,21 +1,22 @@
-import {MessageType} from '../../shared/messages/messageType';
+import { MessageType } from '../../shared/messages/messageType';
 import ClientCommunication from './clientCommunication';
 import _ from 'lodash';
 import WebSocket from 'ws';
-import {Logger} from '../logger';
+import { Logger } from '../logger';
 import CloseEventCode from './closeEventCode';
-
 
 const ClientApi = {
     addClient(client) {
         this.clients.push(client);
         return new Promise((resolve, reject) => {
-            client.on('close', (code, message) => {
+            const closeHandler = (code, message) => {
                 this.clients = this.clients.filter((actClient) => {
                     return actClient !== client;
                 });
-                reject({code, message});
-            });
+                reject({ code, message });
+            };
+            client.on('close', closeHandler);
+            this.disposeFunctions.push(() => client.removeEventListener('close', closeHandler));
         });
     },
 
@@ -125,12 +126,19 @@ const ClientApi = {
 
     setCommunicationProxy(proxyHandler) {
         this.clientCommunication = new Proxy(ClientCommunication, proxyHandler);
+    },
+
+    dispose() {
+        this.disposeFunctions = this.disposeFunctions
+            .map(disposeFunction => disposeFunction())
+            .filter(disposeResult => disposeResult);
     }
 };
 
 export function create(timeoutInMilliseconds = 0) {
     let clientApi = Object.create(ClientApi);
     clientApi.clients = [];
+    clientApi.disposeFunctions = [];
     clientApi.timeoutInSeconds = timeoutInMilliseconds;
     clientApi.clientCommunication = ClientCommunication;
     return clientApi;

--- a/server/session/singleGameSession.js
+++ b/server/session/singleGameSession.js
@@ -255,6 +255,10 @@ const Session = {
             this.close(message);
             SessionHandler.removeSession(this);
         }
+    },
+
+    dispose() {
+        this.clientApi.dispose();
     }
 };
 

--- a/server/session/tournamentSession.js
+++ b/server/session/tournamentSession.js
@@ -177,8 +177,10 @@ const TournamentSession = {
                     if (!player1.connected || !player2.connected) {
                         sessionPromise = this.handlePairingWithDisconnectedClients(pairing);
                     } else {
-                        sessionPromise = createSessionWithPlayers(pairing).start()
-                            .then(this.handleSessionFinish.bind(this, pairing), this.handleSessionFinish.bind(this, pairing));
+                        const singleGameSession = createSessionWithPlayers(pairing);
+                        sessionPromise = singleGameSession.start()
+                            .then(this.handleSessionFinish.bind(this, pairing), this.handleSessionFinish.bind(this, pairing))
+                            .then(() => singleGameSession.dispose());
                     }
 
                     sessionPromise.then(() => {

--- a/test/server/communication/clientApiTest.js
+++ b/test/server/communication/clientApiTest.js
@@ -46,6 +46,13 @@ describe('Client API', () => {
             expect(clientApi.clients[0]).to.equal(webSocket);
         });
 
+        it('should add dispose function for each client', () => {
+            clientApi.addClient(webSocket);
+            clientApi.addClient(webSocket);
+
+            expect(clientApi.disposeFunctions).to.have.lengthOf(2);
+        });
+
         it('should reject promise and remove client on close event', (done) => {
             let disconnectMessage = 'message';
             let webSocket1 = new WebSocket('ws://localhost:10001');
@@ -655,6 +662,35 @@ describe('Client API', () => {
 
             clientApi.requestPlayerName('testClient');
             sinon.assert.neverCalled(requestSpy);
+        });
+    });
+
+    describe('dispose', () => {
+        it('should call all dispose functions', () => {
+            const webSocket = {
+                on() {},
+                removeEventListener: sinon.spy(),
+            };
+            clientApi.addClient(webSocket);
+            clientApi.addClient(webSocket);
+
+            clientApi.dispose();
+
+            sinon.assert.calledTwice(webSocket.removeEventListener);
+            sinon.assert.calledWith(webSocket.removeEventListener, 'close', sinon.match.func);
+        });
+
+        it('should clean dispose functions array', () => {
+            const webSocket = {
+                on() {},
+                removeEventListener() {},
+            };
+            clientApi.addClient(webSocket);
+            clientApi.addClient(webSocket);
+
+            clientApi.dispose();
+
+            expect(clientApi.disposeFunctions).to.have.lengthOf(0);
         });
     });
 });


### PR DESCRIPTION
dispose websocket listeners on single game in tournament
* since the socket stays open during the whole tournament there are possibly a lot of listeners leaking memory