### PR TITLE
change state on choose card to prevent multichoose

### DIFF
--- a/client/js/game/gameStore.js
+++ b/client/js/game/gameStore.js
@@ -9,6 +9,7 @@ export const GameState = {
     REQUESTING_TRUMPF: 'REQUESTING_TRUMPF',
     TRUMPF_CHOSEN: 'TRUMPF_CHOSEN',
     REQUESTING_CARD: 'REQUESTING_CARD',
+    PLAYED_CARD: 'PLAYED_CARD',
     REJECTED_CARD: 'REJECTED_CARD',
     REQUESTING_CARDS_FROM_OTHER_PLAYERS: 'REQUESTING_CARDS_FROM_OTHER_PLAYERS',
     STICH: 'STICH'
@@ -152,6 +153,7 @@ const GameStore = Object.assign(Object.create(EventEmitter.prototype), {
                 this.state.playerCards = this.state.playerCards.filter((card) => {
                     return !card.equals(chosenCard);
                 });
+                this.state.status = GameState.PLAYED_CARD;
                 this.emit('change');
                 break;
             case JassAppConstants.REJECT_CARD:

--- a/test/client/game/gameStoreTest.js
+++ b/test/client/game/gameStoreTest.js
@@ -170,6 +170,23 @@ describe('GameStore', () => {
         ]);
     });
 
+    it('should set game state to PLAYED_CARD on chooseCard', () => {
+        let dummyPayload = {
+            action: {
+                actionType: JassAppConstants.CHOOSE_CARD,
+                data: {
+                    color: CardColor.HEARTS,
+                    number: 9
+                }
+            }
+        };
+        GameStore.state.playerCards = [];
+
+        GameStore.handleAction(dummyPayload);
+
+        expect(GameStore.state.status).to.equal(GameState.PLAYED_CARD);
+    });
+
     it('should calculate team points and set Player to start next turn on broadcast stich', () => {
         let dummyPayload = {
             action: {


### PR DESCRIPTION
Due to the delay until game state changes from server state you could select multiple cards when clicking fast. Now the state is changed immediately and further clicks will be prevented